### PR TITLE
feat(workers): Markdown for Agents content negotiation

### DIFF
--- a/workers/markdown-negotiation/package.json
+++ b/workers/markdown-negotiation/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "wiki-markdown-negotiation",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev"
+  },
+  "devDependencies": {
+    "wrangler": "^3"
+  }
+}

--- a/workers/markdown-negotiation/src/index.js
+++ b/workers/markdown-negotiation/src/index.js
@@ -1,0 +1,51 @@
+/**
+ * Markdown for Agents — Cloudflare Worker
+ *
+ * Content negotiation: requests with `Accept: text/markdown` receive the raw
+ * Markdown source from the GitHub repo instead of rendered HTML.
+ * All other requests are proxied transparently to GitHub Pages.
+ *
+ * Response headers:
+ *   Content-Type: text/markdown; charset=utf-8
+ *   x-markdown-tokens: <estimated token count>
+ */
+
+const GITHUB_RAW_BASE =
+  "https://raw.githubusercontent.com/PixiBixi/pixibixi.github.io/master/docs";
+
+export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+    const accept = request.headers.get("Accept") || "";
+
+    if (accept.includes("text/markdown")) {
+      // Normalize path: strip trailing slash, default root to index
+      const path = url.pathname.replace(/\/$/, "") || "/index";
+      const rawUrl = `${GITHUB_RAW_BASE}${path}.md`;
+
+      const mdResponse = await fetch(rawUrl, {
+        cf: { cacheEverything: true, cacheTtl: 3600 },
+      });
+
+      if (mdResponse.ok) {
+        const content = await mdResponse.text();
+        // Rough token estimate: ~4 chars per token (GPT/Claude approximation)
+        const tokenEstimate = Math.ceil(content.length / 4);
+
+        return new Response(content, {
+          status: 200,
+          headers: {
+            "Content-Type": "text/markdown; charset=utf-8",
+            "x-markdown-tokens": String(tokenEstimate),
+            "Cache-Control": "public, max-age=3600",
+            Vary: "Accept",
+          },
+        });
+      }
+      // Markdown source not found (e.g. /sitemap.xml) — fall through to HTML
+    }
+
+    // Default: proxy to GitHub Pages origin unchanged
+    return fetch(request);
+  },
+};

--- a/workers/markdown-negotiation/wrangler.toml
+++ b/workers/markdown-negotiation/wrangler.toml
@@ -1,0 +1,8 @@
+name            = "wiki-markdown-negotiation"
+main            = "src/index.js"
+compatibility_date = "2024-09-23"
+
+# Route: intercept all requests to the wiki
+[[routes]]
+pattern   = "wiki.jdelgado.fr/*"
+zone_name = "jdelgado.fr"


### PR DESCRIPTION
## Summary

- Cloudflare Worker that intercepts `Accept: text/markdown` requests and returns raw Markdown source from the GitHub repo instead of rendered HTML
- HTML requests proxied unchanged to GitHub Pages
- `Content-Type: text/markdown; charset=utf-8` + `x-markdown-tokens` token-count header on markdown responses
- `Vary: Accept` ensures correct cache behaviour

## Why a Worker instead of the Cloudflare zone setting

The zone-level `content_converter` feature requires **Pro plan**. The Worker approach works on Cloudflare's free tier and gives full control over the path→source mapping.

## How it works

URL path mapping: `wiki.jdelgado.fr/linux/cli/sed/` → `raw.githubusercontent.com/.../docs/linux/cli/sed.md`

## Deploy

```bash
cd workers/markdown-negotiation
npm install
npx wrangler deploy   # requires wrangler login + zone_name "jdelgado.fr" in Cloudflare account
```

## Test plan

- [ ] `curl https://wiki.jdelgado.fr/linux/cli/sed/ -H "Accept: text/markdown"` → returns `.md` source with `Content-Type: text/markdown`
- [ ] `curl https://wiki.jdelgado.fr/linux/cli/sed/` → returns HTML (no header)
- [ ] Response has `x-markdown-tokens` header
- [ ] Validate via `POST https://isitagentready.com/api/scan` with `{"url": "https://wiki.jdelgado.fr"}`